### PR TITLE
docs: local-WIP recipe + published precondition + fix self-contradictions (spelling/output/default-N)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Test the downstream impact of Rust crate changes before publishing. Locate regressions and API breakages.**
 
-Test `any versions of your crate and/or a local WIP version` X `any versions of any specified dependents` (defaults to top 10 most popular dependents).
+Test `any versions of your crate and/or a local WIP version` X `any versions of any specified dependents` (defaults to the top 5 most-downloaded dependents).
 
 Let natural version resolution take place `--test-versions "0.8.50 0.8.51"` (to simulate publishing to crates.io)<br/>
 OR use `--force-versions "0.8.52 0.8.53"` to simulate them upgrading to a new version of your crate with an edit of their cargo.toml.
@@ -20,10 +20,53 @@ cargo binstall cargo-copter
 cargo install cargo-copter
 ```
 
-## Test your local crate version against top dependents
+## Invocation
+
+Invoke the binary directly as **`cargo-copter`**:
+
 ```bash
 cd my-crate
-cargo copter --top-dependents 2
+cargo-copter --top-dependents 2
+```
+
+> **Note:** invoke `cargo-copter` (with the hyphen), not `cargo copter` (space). The
+> `cargo <subcommand>` dispatch form is not wired up in this release, so `cargo copter ...`
+> fails with `unexpected argument 'copter' found`. Use `cargo-copter ...` directly.
+
+## Test your local work-in-progress version
+
+There is **no `--wip` flag**. Running `cargo-copter` from your crate's directory (or with
+`--path <DIR>`) and **without** any of `--crate`, `--test-versions`, or `--force-versions`
+is what offers your local WIP version. In that default mode each dependent is tested twice:
+
+1. **baseline** — the latest version of your crate currently published on crates.io
+2. **WIP** — your uncommitted local source (the version in your local `Cargo.toml`)
+
+so you see exactly what your unpublished changes do to each dependent versus what they
+already ship against.
+
+```bash
+cd my-crate
+cargo-copter --top-dependents 2      # baseline (published) + your local WIP, vs top 2 dependents
+```
+
+### Precondition: default dependent discovery needs your crate published
+
+When you don't pass any `--dependent*` flag, dependents are discovered via the **crates.io
+reverse-dependencies API** for your crate. A brand-new crate that has never been published
+(or one that nothing depends on yet) therefore finds **zero** dependents and exits with
+`Configuration error: No dependents to test`.
+
+For an **unpublished** crate, point cargo-copter at local dependents instead — these paths
+are read straight from disk and never touch crates.io:
+
+```bash
+# Unpublished crate: name the local dependents explicitly
+cargo-copter --path . --dependent-paths ~/work/dep-a ~/work/dep-b
+
+# ...or auto-discover local dependents (only crates that actually depend on yours are kept)
+cargo-copter --path . --dependent-dir ~/work/ ~/work/zen/
+cargo-copter --path . --dependent-glob "~/work/*/Cargo.toml"
 ```
 
 ## Example Output
@@ -64,8 +107,8 @@ Passed test                              2               2          -1 → 1
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Fully passing                            2               2          -1 → 1
 
-Markdown report: copter-report.md
-Detailed failure logs: copter-failures.log
+Markdown report: copter-report/report.md
+Detailed failure logs: copter-report/failures.log
 
 💡 To analyze API changes that may have caused regressions:
    cargo install cargo-public-api
@@ -177,18 +220,19 @@ cargo-copter --top-dependents 5 --top-versions 50
 - Always tests the exact version specified
 - Auto-adds patch mode test unless --skip-normal-testing
 
-### Transitive Patch Mode (--patch-transitive)
-- Adds `[patch.crates-io]` to dependent's Cargo.toml
-- Unifies ALL versions of your crate across the entire dependency tree
-- Resolves "multiple versions of crate X" errors
-- Use when dependents have transitive deps that also use your crate
+### Transitive unification (automatic)
+When a forced version produces a "multiple versions of crate X" error — because a dependent
+pulls in your crate both directly and transitively (e.g. testing `rgb` against `image`, which
+depends on `ravif`, which also uses `rgb`) — cargo-copter **automatically retries** with
+`[patch.crates-io]` applied to unify all copies of your crate across the dependency tree. No
+flag is required. Retried rows are tagged in the output:
 
-Example: Testing `rgb` against `image` which depends on `ravif` which also uses `rgb`:
-```bash
-cargo-copter --dependents image --patch-transitive
-```
-Without `--patch-transitive`, `image` might fail with "the trait `AsPixels` is not implemented"
-because `image` uses one version of `rgb` while `ravif` uses another.
+- `[!!]` = auto-patched (needed `[patch.crates-io]` to unify transitive versions)
+- `[!!!]` = deep conflict (still failed even after `[patch.crates-io]`; see the blocking deps)
+
+> The old `--patch-transitive` flag is **deprecated and hidden** — it is now a no-op, since
+> auto-retry handles transitive unification on its own. It is kept only for backwards
+> compatibility and prints a deprecation notice if you pass it.
 
 ## Caching
 


### PR DESCRIPTION
Found via an **insulated "external developer" usability test** of the published `cargo-copter` 0.3.0 README. The primary local-WIP path was concrete but had several self-contradictions and one unstated precondition. Every claim below was verified against `main` source **and** by building + running the binary.

## Fixes (each verified)

1. **Local-WIP recipe + published-crate precondition (the key gap).** There is no named "WIP flag". Documented that running `cargo-copter` from the crate dir (or `--path`) with **no** `--crate`/`--test-versions`/`--force-versions` is what offers the local WIP version (baseline = latest published, plus WIP = local source). Also documented the precondition the test surfaced: default dependent discovery queries the **crates.io reverse-dependencies API**, so a brand-new/unpublished crate finds zero dependents and exits with `Configuration error: No dependents to test`. Added the `--dependent-paths` / `--dependent-dir` / `--dependent-glob` escape hatch for unpublished crates (read from disk, never touch crates.io).
   - Source: `src/config.rs:228-245` (default baseline+WIP), `src/config.rs:436` + `src/api.rs:55` (`crate_reverse_dependencies_page`), `src/config.rs:469` (`No dependents to test`), `src/config.rs:402` (local-paths branch).
   - Verified by running: with `--dependent-paths`, the tool offered the local WIP version and never hit crates.io; without any `--dependent*` flag on an unpublished crate it printed `No dependents to test`.

2. **Spelling contradiction (`cargo copter` vs `cargo-copter`).** Standardized on `cargo-copter`. The `cargo <subcommand>` dispatch form does **not** work in this release — the binary does not consume the `copter` token cargo injects, so `cargo copter ...` fails with `unexpected argument 'copter' found`. Added a note telling users to invoke `cargo-copter` directly.
   - Source: `src/cli.rs:14` (`name = "cargo-copter"`), no subcommand-token stripping anywhere in `src/`.
   - Verified by running: `cargo copter --help` (binary on PATH) → `error: unexpected argument 'copter' found`, rc=2.

3. **Output-location contradiction.** The "Example Output" footer said `copter-report.md` + `copter-failures.log`; the real output is the `copter-report/` directory with `report.md`, `report.json`, `failures.log`. Fixed the footer to match (the "Reports" section was already correct).
   - Source: `src/main.rs:87` (`copter-report/`), `:312` (`report.md`), `:332` (`report.json`), `src/report.rs:1573` (`failures.log`).
   - Verified by running: output printed `copter-report/{report.md,report.json,failures.log}`.

4. **Default-N contradiction.** Intro prose said "top 10 most popular dependents" but the real default is 5. Changed prose to "top 5".
   - Source: `src/cli.rs:27` (`default_value = "5"`); `--help` shows `[default: 5]`.

5. **`--patch-transitive`.** It's a real flag but **deprecated, hidden, and a no-op** (auto-retry replaced it). Rewrote the "Transitive Patch Mode" section to describe the automatic `[patch.crates-io]` retry (with the `[!!]` / `[!!!]` output markers) and noted `--patch-transitive` is a deprecated no-op kept only for backwards compat.
   - Source: `src/cli.rs:116-124` (`[DEPRECATED]`, `hide = true`, `requires = "force_versions"`), `src/config.rs:53-58` (deprecation warning), `src/report.rs:1272` + `src/compile.rs:685-686` (`!!`/`!!!` markers).

## Scope
README.md only (63 insertions, 19 deletions). No code or behavior changes.

> Note for maintainers (not fixed here, docs-only PR): the broken `cargo copter` subcommand dispatch (gap 2) is a real code bug — clap rejects the injected `copter` token. Worth a follow-up to strip it so the natural `cargo copter` form works.
